### PR TITLE
Add initial Jest tests

### DIFF
--- a/__tests__/Overworld.test.js
+++ b/__tests__/Overworld.test.js
@@ -1,0 +1,40 @@
+const Overworld = require('../Overworld');
+const Person = require('../Person');
+const { createFakeServer } = require('./TestHelpers');
+
+describe('Overworld', () => {
+    test('isSpaceTaken checks walls', () => {
+        const server = createFakeServer();
+        const world = new Overworld({ id: 'W1', characters: {}, walls: { '1,1': true }, portals: {} }, server);
+        expect(world.isSpaceTaken(0, 1, 'right')).toBe(true);
+    });
+
+    test('addWall and removeWall modify walls', () => {
+        const server = createFakeServer();
+        const world = new Overworld({ id: 'W1', characters: {}, walls: {}, portals: {} }, server);
+        world.addWall(2, 3);
+        expect(world.walls['2,3']).toBe(true);
+        world.removeWall(2, 3);
+        expect(world.walls['2,3']).toBeUndefined();
+    });
+
+    test('moveWall moves an existing wall', () => {
+        const server = createFakeServer();
+        const world = new Overworld({ id: 'W1', characters: {}, walls: { '1,1': true }, portals: {} }, server);
+        world.moveWall(1, 1, 'right');
+        expect(world.walls['2,1']).toBe(true);
+        expect(world.walls['1,1']).toBeUndefined();
+    });
+
+    test('usePortal moves person to destination overworld', () => {
+        const server = createFakeServer();
+        const destWorld = new Overworld({ id: 'dest', characters: {}, walls: {}, portals: {} }, server);
+        server.overworlds.set('dest', destWorld);
+        const world = new Overworld({ id: 'W1', characters: {}, walls: {}, portals: { '0,0': { dest: 'dest', x: 5, y: 5, direction: 'down' } } }, server);
+        const person = new Person({ id: 'p', x: 0, y: 0 }, server).mount(world);
+        world.usePortal(0, 0, 'down', person);
+        expect(person.overworld).toBe(destWorld);
+        expect(person.x).toBe(5);
+        expect(person.y).toBe(5);
+    });
+});

--- a/__tests__/Person.test.js
+++ b/__tests__/Person.test.js
@@ -1,0 +1,49 @@
+const Person = require('../Person');
+const { createFakeServer, createFakeOverworld } = require('./TestHelpers');
+
+describe('Person', () => {
+    test('mount adds character to overworld', () => {
+        const server = createFakeServer();
+        const world = createFakeOverworld('DemoRoom', server);
+        const person = new Person({ id: 'p1', x: 1, y: 2 }, server);
+        person.mount(world);
+        expect(world.characters.get('p1')).toBe(person);
+        expect(world.walls['1,2']).toBe(true);
+    });
+
+    test('unmount removes character from overworld', () => {
+        const server = createFakeServer();
+        const world = createFakeOverworld('DemoRoom', server);
+        const person = new Person({ id: 'p2', x: 1, y: 1 }, server).mount(world);
+        person.unmount();
+        expect(world.characters.has('p2')).toBe(false);
+        expect(world.walls['1,1']).toBeUndefined();
+        expect(person.overworld).toBeNull();
+    });
+
+    test('updatePosition changes coordinates', () => {
+        const server = createFakeServer();
+        const world = createFakeOverworld('DemoRoom', server);
+        const person = new Person({ id: 'p3', x: 0, y: 0, facing: 'right' }, server).mount(world);
+        person.updatePosition();
+        expect(person.x).toBe(1);
+        person.facing = 'down';
+        person.updatePosition();
+        expect(person.y).toBe(1);
+    });
+
+    test('toJSON returns basic data', () => {
+        const server = createFakeServer();
+        const world = createFakeOverworld('DemoRoom', server);
+        const person = new Person({ id: 'p4', x: 3, y: 4 }, server).mount(world);
+        const json = person.toJSON();
+        expect(json).toEqual({
+            id: 'p4',
+            x: 3,
+            y: 4,
+            facing: 'down',
+            src: './assets/none.png',
+            world: 'DemoRoom'
+        });
+    });
+});

--- a/__tests__/Player.test.js
+++ b/__tests__/Player.test.js
@@ -1,0 +1,27 @@
+const Player = require('../Player');
+const { createFakeServer, createFakeOverworld } = require('./TestHelpers');
+
+describe('Player', () => {
+    test('constructor mounts player and joins room', () => {
+        const server = createFakeServer();
+        const world = createFakeOverworld('DemoRoom', server);
+        server.database.players.user = { x: 0, y: 0, map: 'DemoRoom', skin: 'hero', isPlayer: true };
+        const socket = { join: jest.fn(), emit: jest.fn(), to: jest.fn(() => ({ emit: jest.fn() })), on: jest.fn() };
+        const player = new Player('user', socket, server);
+        expect(player.username).toBe('user');
+        expect(socket.join).toHaveBeenCalledWith('DemoRoom');
+        expect(server.overworlds.get('DemoRoom').characters.get('user')).toBe(player);
+    });
+
+    test('toJSON contains player info', () => {
+        const server = createFakeServer();
+        const world = createFakeOverworld('DemoRoom', server);
+        server.database.players.user = { x: 1, y: 2, map: 'DemoRoom', skin: 'hero', isPlayer: true };
+        const socket = { join: jest.fn(), emit: jest.fn(), to: jest.fn(() => ({ emit: jest.fn() })), on: jest.fn() };
+        const player = new Player('user', socket, server);
+        const json = player.toJSON();
+        expect(json.isPlayer).toBe(true);
+        expect(json.username).toBe('user');
+        expect(json.world).toBe('DemoRoom');
+    });
+});

--- a/__tests__/Server.test.js
+++ b/__tests__/Server.test.js
@@ -1,0 +1,16 @@
+jest.mock('../Player');
+const Server = require('../Server');
+const Player = require('../Player');
+
+describe('Server', () => {
+    test('constructor loads overworlds', () => {
+        const server = new Server();
+        expect(server.overworlds.size).toBeGreaterThan(0);
+        expect(server.database).toHaveProperty('players');
+    });
+
+    test('onNewPlayer exists', () => {
+        const server = new Server();
+        expect(typeof server.onNewPlayer).toBe('function');
+    });
+});

--- a/__tests__/TestHelpers.js
+++ b/__tests__/TestHelpers.js
@@ -1,0 +1,28 @@
+class FakeIO {
+    constructor() {
+        this.emitted = [];
+    }
+    to(room) {
+        return {
+            emit: (event, ...args) => {
+                this.emitted.push({ room, event, args });
+            }
+        };
+    }
+}
+
+function createFakeServer() {
+    return {
+        io: new FakeIO(),
+        overworlds: new Map(),
+        database: { players: { test: { x: 0, y: 0, map: 'DemoRoom', skin: 'hero', isPlayer: true } }, maps: {} }
+    };
+}
+
+function createFakeOverworld(id, server) {
+    const overworld = new (require('../Overworld'))({ id, characters: {}, walls: {}, portals: {} }, server);
+    server.overworlds.set(id, overworld);
+    return overworld;
+}
+
+module.exports = { FakeIO, createFakeServer, createFakeOverworld };

--- a/__tests__/Utils.test.js
+++ b/__tests__/Utils.test.js
@@ -1,0 +1,38 @@
+const Utils = require('../Utils');
+
+describe('Utils', () => {
+    test('withGrid multiplies by 16', () => {
+        expect(Utils.withGrid(2)).toBe(32);
+    });
+
+    test('asGridCoord formats coordinates', () => {
+        expect(Utils.asGridCoord(1, 2)).toBe('16,32');
+    });
+
+    test('nextPosition moves left', () => {
+        const pos = Utils.nextPosition(5, 5, 'left');
+        expect(pos).toEqual({ x: 4, y: 5 });
+    });
+
+    test('nextPosition moves right', () => {
+        const pos = Utils.nextPosition(5, 5, 'right');
+        expect(pos).toEqual({ x: 6, y: 5 });
+    });
+
+    test('nextPosition moves up', () => {
+        const pos = Utils.nextPosition(5, 5, 'up');
+        expect(pos).toEqual({ x: 5, y: 4 });
+    });
+
+    test('nextPosition moves down', () => {
+        const pos = Utils.nextPosition(5, 5, 'down');
+        expect(pos).toEqual({ x: 5, y: 6 });
+    });
+
+    test('oppositeDirection returns inverse', () => {
+        expect(Utils.oppositeDirection('left')).toBe('right');
+        expect(Utils.oppositeDirection('right')).toBe('left');
+        expect(Utils.oppositeDirection('up')).toBe('down');
+        expect(Utils.oppositeDirection('down')).toBe('up');
+    });
+});

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,0 +1,9 @@
+jest.mock('../Server');
+const Server = require('../Server');
+
+describe('index file', () => {
+    test('creates a new Server', () => {
+        require('../index');
+        expect(Server).toHaveBeenCalled();
+    });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    testEnvironment: 'node'
+};

--- a/package.json
+++ b/package.json
@@ -10,9 +10,13 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "jest"
   },
   "author": "",
   "license": "ISC",
-  "description": ""
+  "description": "",
+  "devDependencies": {
+    "jest": "^29.6.0"
+  }
 }


### PR DESCRIPTION
## Summary
- add Jest configuration and scripts
- create helper utilities for test mocks
- add test coverage for Utils, Person, Player, Overworld, Server and index modules

## Testing
- `node --check __tests__/Overworld.test.js`
- `node --check __tests__/Person.test.js`
- `node --check __tests__/Player.test.js`
- `node --check __tests__/Server.test.js`
- `node --check __tests__/TestHelpers.js`
- `node --check __tests__/Utils.test.js`
- `node --check __tests__/index.test.js`
- `node --check jest.config.js`
- `node index.js` *(terminated after startup)*
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_685d2665be7c8324930834be618d6daa